### PR TITLE
Fix CStorable default implementation

### DIFF
--- a/Foreign/CStorable/TypeClass.hs
+++ b/Foreign/CStorable/TypeClass.hs
@@ -80,4 +80,4 @@ class CStorable a where
 
   cSizeOf            :: a -> Int
   default cSizeOf    :: (Generic a, GCStorable (Rep a)) => a -> Int
-  cSizeOf            = gcAlignment . from
+  cSizeOf            = gcSizeOf . from


### PR DESCRIPTION
Hi, this is a small patch to fix a copy-paste error in the default implementation of the CStorable instance.
