### PR TITLE
Fix so the library builds on Windows/mingw32

### DIFF
--- a/Foreign/CStorable/BaseInstances.hs
+++ b/Foreign/CStorable/BaseInstances.hs
@@ -57,6 +57,8 @@ C(CChar)
 C(IntPtr)
 C(WordPtr)
 C(Fd)
+
+#ifndef mingw32_HOST_OS
 C(CRLim)
 C(CTcflag)
 C(CSpeed)
@@ -64,6 +66,8 @@ C(CCc)
 C(CUid)
 C(CNlink)
 C(CGid)
+#endif
+
 C(CSsize)
 C(CPid)
 C(COff)


### PR DESCRIPTION
BaseInstances had a few posix types that (presumably) are not available on mingw32, so I have added a test to see if the library is being built on mingw32 and excludes those types if required
