### PR TITLE
docs: example

### DIFF
--- a/README
+++ b/README
@@ -1,1 +1,0 @@
-This library is intended to make generating C-like storable instances from datatypes easy.

--- a/README.md
+++ b/README.md
@@ -1,0 +1,27 @@
+# c-storable-deriving
+
+This library is intended to make generating C-like storable instances from datatypes easy.
+
+## Example
+
+```haskell
+{-# LANGUAGE DeriveGeneric, DeriveAnyClass #-}
+
+import Foreign (Storable(..))
+import Foreign.CStorable (CStorable(..))
+
+-- | a two-dimensional point.
+-- Compatible with both OSX's @CGPoint@ and Window's @POINT@.
+data Point = Point
+ { x :: Double
+ , y :: Double
+ } deriving (Generic,CStorable)
+
+instance Storable Point where
+ peek      = cPeek
+ poke      = cPoke
+ alignment = cAlignment
+ sizeOf    = cSizeOf
+```
+
+See the haddocks for further details: [Foreign.CStorable](https://hackage.haskell.org/package/c-storable-deriving/docs/Foreign-CStorable.html)


### PR DESCRIPTION
derive CStorable for a Point type

haddocks / README only

we should also later add it into an ".Example" module, as a "static test". 
#8
