### PR TITLE
docs: add import to build example

### DIFF
--- a/Foreign/CStorable/TypeClass.hs
+++ b/Foreign/CStorable/TypeClass.hs
@@ -73,6 +73,7 @@ instance (CStorable a) => GCStorable (K1 i a) where
 -- @
 -- {-\# LANGUAGE <https://ocharles.org.uk/blog/posts/2014-12-16-derive-generic.html DeriveGeneric>, <http://dev.stephendiehl.com/hask/#deriveanyclass DeriveAnyClass> \#-}
 --
+-- import GHC.Generics (Generic(..))
 -- import 'Foreign' (Storable(..))
 -- import Foreign.CStorable (CStorable(..))
 --
@@ -81,7 +82,7 @@ instance (CStorable a) => GCStorable (K1 i a) where
 -- data Point = Point
 --  { x :: Double
 --  , y :: Double
---  } deriving ('Generic','CStorable')
+--  } deriving ('Generic', 'CStorable')
 --
 -- instance 'Storable' Point where
 --  'peek'      = 'cPeek'

--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@ This library is intended to make generating C-like storable instances from datat
 ```haskell
 {-# LANGUAGE DeriveGeneric, DeriveAnyClass #-}
 
+import GHC.Generics (Generic(..))
 import Foreign (Storable(..))
 import Foreign.CStorable (CStorable(..))
 
@@ -15,7 +16,7 @@ import Foreign.CStorable (CStorable(..))
 data Point = Point
  { x :: Double
  , y :: Double
- } deriving (Generic,CStorable)
+ } deriving (Generic, CStorable)
 
 instance Storable Point where
  peek      = cPeek


### PR DESCRIPTION
Fixes the build error for anyone blindly copying and pasting the example to give it a go (guilty).
